### PR TITLE
fix device not booting when built with  > Clang 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -749,7 +749,7 @@ ifdef CONFIG_CC_OPTIMIZE_FOR_SIZE
 KBUILD_CFLAGS   += -Os
 else
 ifeq ($(cc-name),clang)
-KBUILD_CFLAGS   += -O3 -finline-hint-functions
+KBUILD_CFLAGS   += -O3 -finline-hint-functions -falign-loops=1
 else
 KBUILD_CFLAGS   += -O3
 endif


### PR DESCRIPTION
this workaround fixes mido not booting due to following commit ( https://github.com/llvm/llvm-project/commit/7d676714fbf2dd4bcdd15bd63d6b43b467ceccb1 ) in llvm backend if kernel is built with Clang 15 or Greater.